### PR TITLE
Remove invalid mod tag from ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -23,7 +23,7 @@
 		"24": "icon/icon.png"
 	},
 	"repository": "https://github.com/Ronkad/CCRemasteredMelodies",
-	"tags": ["music", "OST"],
+	"tags": ["music"],
 	"authors": ["Ronkad", "elluminance"],
 	"prestart": "prestart.js",
 	"dependencies": {


### PR DESCRIPTION
I have started enforcing all mod tags to be in the official specification.
I've added the new `music` tag, but not the `OST`.